### PR TITLE
Drop minimum .NET Framework to 4.0

### DIFF
--- a/BasicThemer2/BasicThemer2.csproj
+++ b/BasicThemer2/BasicThemer2.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>BasicThemer2</RootNamespace>
     <AssemblyName>BasicThemer2</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
Should into Windows 8.0 for sure now. If it somehow STILL doesn't, well...at least we'll know something else was amiss all along.